### PR TITLE
feat: Read LLM model from environment variable with fallback

### DIFF
--- a/adk/hs_optimizer/agent.py
+++ b/adk/hs_optimizer/agent.py
@@ -1,5 +1,5 @@
-import pandas as pd
 import os
+import pandas as pd
 import warnings
 import joblib
 from typing import Optional, List, Dict, Any, Callable
@@ -264,7 +264,9 @@ def read_model_history_tool():
 
 
 # Default LLM for code generation
-DEFAULT_MODEL = LiteLlm(model="openai/gpt-4.1-mini")
+DEFAULT_MODEL = LiteLlm(
+    model=os.environ.get("LLM_MODEL", "openai/gpt-5-nano")
+)
 
 # --- SUB-AGENT: Model Code Generator ---
 # Generates Python code files defining a load_model function per CLI contract


### PR DESCRIPTION
Modified `adk/hs_optimizer/agent.py` to attempt to read the LLM model from the `LLM_MODEL` environment variable.

If the environment variable is not set, it falls back to the new default model, "openai/gpt-5-nano".

This provides more flexibility for configuring the agent without changing the code.